### PR TITLE
Update ghostscript to 9.25

### DIFF
--- a/org.kde.okular.yaml
+++ b/org.kde.okular.yaml
@@ -83,8 +83,8 @@ modules:
       - /share/ghostscript/9.24/examples
     sources:
     - type: archive
-      url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs924/ghostscript-9.24.tar.xz
-      sha256: d44917df24979a05e0cb3916531928cc2adc91f5b17b419ee023d16ab31069d6
+      url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-9.25.tar.xz
+      sha256: a2971a23bf15bbd9ddcd173141b15504e51ddc1d5a0a0144b00a6a8b14a62fed
     - type: shell
       commands:
         - cp -p /usr/share/automake-*/config.{sub,guess} freetype/builds/unix/

--- a/org.kde.okular.yaml
+++ b/org.kde.okular.yaml
@@ -79,8 +79,8 @@ modules:
       - soinstall
     cleanup:
       - /bin
-      - /share/ghostscript/9.24/doc/
-      - /share/ghostscript/9.24/examples
+      - /share/ghostscript/9.25/doc/
+      - /share/ghostscript/9.25/examples
     sources:
     - type: archive
       url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-9.25.tar.xz


### PR DESCRIPTION
This is another urgent security update of ghostscript, more info at https://www.ghostscript.com/doc/9.25/News.htm