### PR TITLE
Update ghostscript to 9.26

### DIFF
--- a/org.kde.okular.yaml
+++ b/org.kde.okular.yaml
@@ -80,12 +80,12 @@ modules:
       - soinstall
     cleanup:
       - /bin
-      - /share/ghostscript/9.25/doc/
-      - /share/ghostscript/9.25/examples
+      - /share/ghostscript/9.26/doc/
+      - /share/ghostscript/9.26/examples
     sources:
     - type: archive
-      url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-9.25.tar.xz
-      sha256: a2971a23bf15bbd9ddcd173141b15504e51ddc1d5a0a0144b00a6a8b14a62fed
+      url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.xz
+      sha256: 90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598
     - type: shell
       commands:
         - cp -p /usr/share/automake-*/config.{sub,guess} freetype/builds/unix/


### PR DESCRIPTION
Ghostscript 9.26 is yet another security related related release.
https://www.ghostscript.com/doc/9.26/News.htm