### PR TITLE
Allow access to the host file system

### DIFF
--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -10,6 +10,7 @@
       "--socket=x11",
       "--socket=wayland",
       "--device=dri",
+      "--filesystem=host",
       "--filesystem=xdg-config/kdeglobals:ro"
    ],
    "cleanup": [


### PR DESCRIPTION
Without that permission things like drag and drop don't work.