### PR TITLE
Use the new openjpeg shared module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -161,25 +161,7 @@
             }
          ]
       },
-      {
-         "name": "openjpeg",
-         "buildsystem": "cmake-ninja",
-         "builddir": true,
-         "config-opts": [
-            "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-         ],
-         "cleanup": [
-            "/bin",
-            "/lib/openjpeg-*"
-         ],
-         "sources": [
-            {
-               "type": "archive",
-               "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
-               "sha256": "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9"
-            }
-         ]
-      },
+      "shared-modules/openjpeg/openjpeg.json",
       {
          "name": "poppler-data",
          "buildsystem": "cmake-ninja",


### PR DESCRIPTION
In addition to the long term benefit of a shared maintenance, this also
brings a couple of immediate wins: the cmake/cleanup config should
result in a slightly faster and smaller build.