### PR TITLE
[WIP] Add okular-wrapper

### DIFF
--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -295,6 +295,10 @@
             "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
             "-DBUILD_OKULARKIRIGAMI=OFF"
          ],
+         "post-instal": [
+            "mv /app/bin/okular /app/bin/okular-bin",
+            "install -Dm755 okular-wrapper /app/bin/okular"
+         ],
          "sources": [
             {
                "type": "archive",
@@ -304,6 +308,14 @@
             {
                 "type": "patch",
                 "path": "okular-mimetypes.patch"
+            },
+            {
+                "type": "script",
+                "dest-filename": "okular-wrapper",
+                "commands": [
+                    "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+                    "exec /app/bin/okular \"$@\""
+                ]
             }
          ]
       }


### PR DESCRIPTION
This will allow to set TMPDIR in sandbox to available path on host which is needed to open embedded files.

Fixes https://github.com/flathub/org.kde.okular/issues/62