### PR TITLE
Do not clean /bin from gs, we need pdf2ps et al

### DIFF
--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -129,7 +129,6 @@
             "soinstall"
          ],
          "cleanup": [
-            "/bin",
             "/share/ghostscript/9.52/doc/",
             "/share/ghostscript/9.52/examples"
          ],


### PR DESCRIPTION
To be able of doing print to pdf in some formats

Still doesn't totally work but it's a step, at least the option is there
now in the UI