### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -13,7 +13,12 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
-        "--filesystem=host"
+        "--filesystem=home",
+        "--filesystem=/media",
+        "--filesystem=/mnt",
+        "--filesystem=/run/media",
+        "--filesystem=/var/run/media",
+        "--filesystem=/var/mnt",
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt