### PR TITLE
Remove BUILD_OKULARKIRIGAMI CMake flag

### DIFF
--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -444,8 +444,7 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-                "-DBUILD_OKULARKIRIGAMI=OFF"
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
             ],
             "post-install": [
                 "mv /app/bin/okular /app/bin/okular-bin",


### PR DESCRIPTION
```
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_OKULARKIRIGAMI
```