### PR TITLE
More permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,17 @@
 
 This application requests the following additional permissions:
 
-- Access to the host filesystem: `--filesystem=host`.
-  This is currently required for drag & drop support.
+- Read/write access to the host filesystem: `--filesystem=host`.
+  Required for ‘Open Recent’ and for drag & drop support,
+  see [QTBUG-91357](https://bugreports.qt.io/browse/QTBUG-91357).
+  Write access required for ‘Annotations’ and ‘Digitally Sign…’.
+- Access to network: `--share=network`.
+  Required for opening URLs.
+- Access to audio: `--socket=pulseaudio`.
+  Required for PDFs with sounds, see https://okular.kde.org/formats/.
+- Bluetooth access: `--allow=bluetooth`.
+  Required for ‘Send via Bluetooth…’.
+- Talk to session D-Bus: `--talk-name=org.freedesktop.ScreenSaver`.
+  Required to inhibit screen saver while presenting.
+- Talk to session D-Bus: `--talk-name=org.freedesktop.login1`.
+  Required to inhibit sleep while presenting.

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -13,7 +13,10 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
-        "--filesystem=host"
+        "--filesystem=host",
+        "--allow=bluetooth",
+        "--talk-name=org.freedesktop.ScreenSaver",
+        "--talk-name=org.freedesktop.login1"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
Tried to lower filesystem access to read-only. Write access for ‘Annotations’ is required only because of filesystem permission; without it saving is handled via portals. I haven't tested ‘Digitally Sign…’, but it seems reasonable to assume that it'll behave the same way.

Haven't tested ‘Send via Bluetooth…’.

P.S. Looks like someone actually implemented [portal DnD in KIO](https://invent.kde.org/frameworks/kcoreaddons/-/merge_requests/212).