### PR TITLE
Update runtime, change deps

### DIFF
--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -390,12 +390,63 @@
             ]
         },
         {
+            "name": "libvlc",
+            "config-opts": [
+                "BUILDCC=gcc",
+                "--disable-lua",
+                "--disable-a52",
+                "--disable-qt",
+                "--disable-ncurses",
+                "--disable-udev"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://get.videolan.org/vlc/3.0.21/vlc-3.0.21.tar.xz",
+                    "sha256": "24dbbe1d7dfaeea0994d5def0bbde200177347136dbfe573f5b6a4cee25afbb0",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 6504,
+                        "stable-only": true,
+                        "url-template": "https://get.videolan.org/vlc/$version/vlc-$version.tar.xz"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "vlc-ignore-time-for-cache.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "vlc-taglib-2.patch"
+                }
+            ]
+        },
+        {
+            "name": "phonon-vlc",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DPHONON_BUILD_QT5=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/phonon/phonon-backend-vlc/0.12.0/phonon-backend-vlc-0.12.0.tar.xz",
+                    "sha256": "338479dc451e4b94b3ca5b578def741dcf82f5c626a2807d36235be2dce7c9a5",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 229046,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/phonon/phonon-backend-vlc/$version/phonon-backend-vlc-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
             "name": "okular",
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-                "-DFORCE_NOT_REQUIRED_DEPENDENCIES=Phonon4Qt6"
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
             ],
             "post-install": [
                 "mv /app/bin/okular /app/bin/okular-bin",

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -390,6 +390,27 @@
             ]
         },
         {
+            "name": "ffmpeg",
+            "config-opts": [
+                "--enable-pic",
+                "--enable-shared",
+                "--disable-doc",
+                "--disable-static",
+                "--enable-gpl",
+                "--enable-libvpx",
+                "--enable-libmp3lame",
+                "--enable-libvorbis",
+                "--enable-libopus"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ffmpeg.org/releases/ffmpeg-4.4.5.tar.xz",
+                    "sha256": "f9514e0d3515aee5a271283df71636e1d1ff7274b15853bcd84e144be416ab07"
+                }
+            ]
+        },
+        {
             "name": "phonon",
             "config-opts": [
                 "-DBUILD_TESTING=OFF",

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.okular",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.7",
+    "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
     "command": "okular",
     "rename-icon": "okular",
@@ -239,31 +239,6 @@
             ]
         },
         {
-            "name": "openjpeg",
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-            ],
-            "cleanup": [
-                "/bin",
-                "/lib/openjpeg-*"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/uclouvain/openjpeg/archive/v2.5.3.tar.gz",
-                    "sha256": "368fe0468228e767433c9ebdea82ad9d801a3ad1e4234421f352c8b06e7aa707",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 2550,
-                        "stable-only": true,
-                        "url-template": "https://github.com/uclouvain/openjpeg/archive/v$version.tar.gz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "poppler-data",
             "buildsystem": "cmake-ninja",
             "builddir": true,
@@ -419,7 +394,8 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DFORCE_NOT_REQUIRED_DEPENDENCIES=Phonon4Qt6"
             ],
             "post-install": [
                 "mv /app/bin/okular /app/bin/okular-bin",

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -390,6 +390,28 @@
             ]
         },
         {
+            "name": "phonon",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF",
+                "-DPHONON_BUILD_QT5=OFF",
+                "-DPHONON_BUILD_QT6=ON"
+            ],
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/phonon/4.12.0/phonon-4.12.0.tar.xz",
+                    "sha256": "3287ffe0fbcc2d4aa1363f9e15747302d0b080090fe76e5f211d809ecb43f39a",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 229047,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/phonon/$version/phonon-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
             "name": "libvlc",
             "config-opts": [
                 "BUILDCC=gcc",

--- a/vlc-ignore-time-for-cache.patch
+++ b/vlc-ignore-time-for-cache.patch
@@ -1,0 +1,26 @@
+From b380b05132521b0c1c18b872eba23d1ebc32e0c9 Mon Sep 17 00:00:00 2001
+From: Mathieu Velten <matmaul@gmail.com>
+Date: Sun, 16 Jun 2019 02:46:56 +0200
+Subject: [PATCH] Ignore time for cache
+
+---
+ src/modules/bank.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/modules/bank.c b/src/modules/bank.c
+index 2e67a0d07e..ab2915fbb7 100644
+--- a/src/modules/bank.c
++++ b/src/modules/bank.c
+@@ -275,8 +275,7 @@ static int AllocatePluginFile (module_bank_t *bank, const char *abspath,
+         plugin = vlc_cache_lookup(&bank->cache, relpath);
+ 
+         if (plugin != NULL
+-         && (plugin->mtime != (int64_t)st->st_mtime
+-          || plugin->size != (uint64_t)st->st_size))
++          && plugin->size != (uint64_t)st->st_size)
+         {
+             msg_Err(bank->obj, "stale plugins cache: modified %s",
+                     plugin->abspath);
+-- 
+2.21.0
+

--- a/vlc-taglib-2.patch
+++ b/vlc-taglib-2.patch
@@ -1,0 +1,63 @@
+diff --git a/modules/meta_engine/taglib.cpp b/modules/meta_engine/taglib.cpp
+index 84b401c795..f371485008 100644
+--- a/modules/meta_engine/taglib.cpp
++++ b/modules/meta_engine/taglib.cpp
+@@ -185,7 +185,7 @@ public:
+         ByteVector res(length, 0);
+         ssize_t i_read = vlc_stream_Read( m_stream, res.data(), length);
+         if (i_read < 0)
+-            return ByteVector::null;
++            return ByteVector();
+         else if ((size_t)i_read != length)
+             res.resize(i_read);
+         return res;
+@@ -465,7 +465,7 @@ static void ReadMetaFromASF( ASF::Tag* tag, demux_meta_t* p_demux_meta, vlc_meta
+ static void ReadMetaFromBasicTag(const Tag* tag, vlc_meta_t *dest)
+ {
+ #define SET( accessor, meta )                                                  \
+-    if( !tag->accessor().isNull() && !tag->accessor().isEmpty() )              \
++    if( !tag->accessor().isEmpty() )              \
+         vlc_meta_Set##meta( dest, tag->accessor().toCString(true) )
+ #define SETINT( accessor, meta )                                               \
+     if( tag->accessor() )                                                      \
+@@ -806,15 +806,15 @@ static void ReadMetaFromMP4( MP4::Tag* tag, demux_meta_t *p_demux_meta, vlc_meta
+ {
+     MP4::Item list;
+ #define SET( keyName, metaName )                                                             \
+-    if( tag->itemListMap().contains(keyName) )                                               \
++    if( tag->itemMap().contains(keyName) )                                               \
+     {                                                                                        \
+-        list = tag->itemListMap()[keyName];                                                  \
++        list = tag->itemMap()[keyName];                                                  \
+         vlc_meta_Set##metaName( p_meta, list.toStringList().front().toCString( true ) );     \
+     }
+ #define SET_EXTRA( keyName, metaName )                                                   \
+-    if( tag->itemListMap().contains(keyName) )                                  \
++    if( tag->itemMap().contains(keyName) )                                  \
+     {                                                                                \
+-        list = tag->itemListMap()[keyName];                                     \
++        list = tag->itemMap()[keyName];                                     \
+         vlc_meta_AddExtra( p_meta, metaName, list.toStringList().front().toCString( true ) ); \
+     }
+ 
+@@ -824,9 +824,9 @@ static void ReadMetaFromMP4( MP4::Tag* tag, demux_meta_t *p_demux_meta, vlc_meta
+ #undef SET
+ #undef SET_EXTRA
+ 
+-    if( tag->itemListMap().contains("covr") )
++    if( tag->itemMap().contains("covr") )
+     {
+-        MP4::CoverArtList list = tag->itemListMap()["covr"].toCoverArtList();
++        MP4::CoverArtList list = tag->itemMap()["covr"].toCoverArtList();
+         const char *psz_format = list[0].format() == MP4::CoverArt::PNG ? "image/png" : "image/jpeg";
+ 
+         msg_Dbg( p_demux_meta, "Found embedded art (%s) is %i bytes",
+@@ -1337,7 +1337,7 @@ static int WriteMeta( vlc_object_t *p_this )
+         if( RIFF::AIFF::File* riff_aiff = dynamic_cast<RIFF::AIFF::File*>(f.file()) )
+             WriteMetaToId3v2( riff_aiff->tag(), p_item );
+         else if( RIFF::WAV::File* riff_wav = dynamic_cast<RIFF::WAV::File*>(f.file()) )
+-            WriteMetaToId3v2( riff_wav->tag(), p_item );
++            WriteMetaToId3v2( riff_wav->ID3v2Tag(), p_item );
+     }
+     else if( TrueAudio::File* trueaudio = dynamic_cast<TrueAudio::File*>(f.file()) )
+     {


### PR DESCRIPTION
Update the runtime to 6.8.
Remove openjpeg, which is now part of the runtime.
~~Remove phonon as a build dependency as [phonon has been removed from the runtime](https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/53). Phonon requires vlc, so it didn't work before anyway (at least that's how I understand the linked conversation). ~~
Add photon and photon-vlc.