### PR TITLE
Update runtime to 6.10

### DIFF
--- a/gnustep-base-fix_GCC15.patch
+++ b/gnustep-base-fix_GCC15.patch
@@ -1,0 +1,11 @@
+--- a/Tools/Makefile.orig.preamble	2024-05-27 08:57:03.000000000 +0200
++++ b/Tools/Makefile.preamble	2025-01-24 21:56:17.830762556 +0100
+@@ -46,7 +46,7 @@
+ #ADDITIONAL_OBJCFLAGS +=
+ 
+ # Additional flags to pass to the C compiler
+-#ADDITIONAL_CFLAGS += 
++ADDITIONAL_CFLAGS += -std=gnu17
+ 
+ # Additional include directories the compiler should search
+ ADDITIONAL_INCLUDE_DIRS += -I../Source/$(GNUSTEP_TARGET_DIR) -I../Source/

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.okular",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "okular",
     "rename-icon": "okular",
@@ -32,11 +32,6 @@
     "modules": [
         {
             "name": "gnustep-make",
-            "buildsystem": "simple",
-            "build-commands": [
-                "./configure --prefix=/app",
-                "make -j $FLATPAK_BUILDER_N_JOBS install"
-            ],
             "sources": [
                 {
                     "type": "archive",
@@ -53,12 +48,6 @@
         },
         {
             "name": "gnustep",
-            "buildsystem": "simple",
-            "build-commands": [
-                "./configure --prefix=/app",
-                "make -j $FLATPAK_BUILDER_N_JOBS install",
-                "ls /app/include"
-            ],
             "sources": [
                 {
                     "type": "archive",
@@ -70,6 +59,10 @@
                         "stable-only": true,
                         "url-template": "https://github.com/gnustep/libs-base/archive/refs/tags/base-$version.tar.gz"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "gnustep-base-fix_GCC15.patch"
                 }
             ]
         },
@@ -176,7 +169,8 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             ],
             "sources": [
                 {


### PR DESCRIPTION
The buildsystem commands are not needed, but clean up the manifest.